### PR TITLE
Add check to not remove keys with value nil

### DIFF
--- a/lib/hash.rb
+++ b/lib/hash.rb
@@ -16,11 +16,11 @@ class Hash
 
     prop = create_prop(method)
 
-    if self[prop].nil?
+    if self[prop].nil? && prop_present?(prop)
       self[prop] = self.delete(prop.to_s)
     end
 
-    super(method, args) and return if self[prop].nil?
+    super(method, args) and return unless prop_present?(prop)
 
     if setter?(method)
       self[prop] = args.first
@@ -29,21 +29,27 @@ class Hash
     end
   end
 
-  private def dotify_hash(hash)
+  private
+
+  def dotify_hash(hash)
     hash.use_dot_syntax = true
 
     hash.keys.each { |key| dotify_hash(hash[key]) if hash[key].is_a?(Hash) }
   end
 
-  private def to_dot?
+  def to_dot?
     self.use_dot_syntax || self.class.use_dot_syntax
   end
 
-  private def setter?(method)
+  def setter?(method)
     method.last == "="
   end
 
-  private def create_prop(method)
+  def create_prop(method)
     setter?(method) ? method.chop : method
+  end
+
+  def prop_present?(prop)
+    self.has_key?(prop) || self.has_key?(prop.to_s)
   end
 end

--- a/spec/hash_dot_spec.rb
+++ b/spec/hash_dot_spec.rb
@@ -23,4 +23,13 @@ describe 'Hash dot syntax' do
 
     it_behaves_like 'an object', -> { {action: :to_dot} }
   end
+
+  context 'given a hash that has a key of value nil' do
+    it 'does not delete the key from the hash' do
+      numbers = { one: 1, two: 2, three: nil }.to_dot
+
+      expect(numbers.three).to be_nil
+      expect{ numbers.four }.to raise_error(NoMethodError)
+    end
+  end
 end


### PR DESCRIPTION
@adsteel This ruby gem came in handy when I needed it. But somehow, it was deleting keys with a value set to nil. So I thought I should fix it. I believe we only want to raise an error for keys that are not present in the hash. Please review and let me know what you think. 