### PR TITLE
Allow respond_to? to return true when key exposed as method.

### DIFF
--- a/lib/hash.rb
+++ b/lib/hash.rb
@@ -25,6 +25,13 @@ class Hash
     end
   end
 
+  def respond_to?(method, include_all=false)
+    return super(method, include_all) unless to_dot?
+    prop = create_prop(method)
+    return true if key?(prop)
+    super(method, include_all)
+  end
+  
   private
 
   def dotify_hash(hash)

--- a/spec/hash_dot_spec.rb
+++ b/spec/hash_dot_spec.rb
@@ -20,6 +20,16 @@ describe "Hash dot syntax" do
       expect( one.a ).to eq( 1 )
       expect { two.a }.to raise_error( NoMethodError )
     end
+    
+    it "says it responds to messages for a specific instance" do
+      one = { a: 1 }.to_dot
+      two = { a: 2 }
+
+      expect( one.respond_to?(:a) ).to be_truthy
+      expect( one.respond_to?(:b) ).to be_falsey
+      expect( two.respond_to?(:a) ).to be_falsey
+    end
+    
 
     it_behaves_like "an object", -> { { action: :to_dot } }
   end


### PR DESCRIPTION
This is a PR that address issue #7. 

This allow respond_to? to give an appropriate answer based on when a key is exposed via dot notation.