### PR TITLE
[feature] Add set new hash property using dot notation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HashDot
 
-HashDot allows you to call your Ruby hash properties with a dot syntax.
+HashDot allows you to get and set your Ruby hash properties with a dot syntax.
 
 ```ruby
   require 'hash_dot'
@@ -12,6 +12,11 @@ HashDot allows you to call your Ruby hash properties with a dot syntax.
   user.job.title #=> 'Senior Programmer'
   user.job.delete(:title)
   user.job.title #=> NoMethodError
+  user.job.title = 'Engineer'
+  user.job.title #=> 'Engineer'
+  user.job.department = 'DevOps'
+  user.job.department #=> 'DevOps'
+  user #=> {:name=>'Anna', :job=>{:title=>'Engineer', :department=>'DevOps'}}
 ```
 
 You can also allow dot syntax for all hashes via the class setting.

--- a/lib/hash.rb
+++ b/lib/hash.rb
@@ -16,11 +16,10 @@ class Hash
 
     prop = create_prop(method)
 
-    super(method, args) && return unless key?(prop)
-
     if setter?(method)
       self[prop] = args.first
     else
+      super(method, args) && return unless key?(prop)
       self[prop]
     end
   end

--- a/spec/hash_dot_spec.rb
+++ b/spec/hash_dot_spec.rb
@@ -21,6 +21,13 @@ describe "Hash dot syntax" do
       expect { two.a }.to raise_error( NoMethodError )
     end
 
+    it "allows dot set for a specific instance" do
+      one = { a: 1 }.to_dot
+      one.b = 2
+      expect( one.a ).to eq( 1 )
+      expect( one.b ).to eq( 2 )
+    end
+
     it "recognizes keys as methods via #respond_to?" do
       one = { a: 1 }.to_dot
       two = { a: 2 }


### PR DESCRIPTION
Reworked `method_missing` method in `hash.rb` so to be able to add missing properties using the dot notation.