### PR TITLE
optionally allow for using the hash's default value instead of raising NoMethodError

### DIFF
--- a/lib/hash.rb
+++ b/lib/hash.rb
@@ -20,7 +20,7 @@ class Hash
 
     if setter?(method)
       self[prop] = args.first
-    elsif key?(prop) || hash_dot_use_default
+    elsif key?(prop) || use_default?
       self[prop]
     else
       super(method, args)
@@ -45,6 +45,10 @@ class Hash
 
   def to_dot?
     use_dot_syntax || self.class.use_dot_syntax
+  end
+
+  def use_default?
+    hash_dot_use_default || self.class.hash_dot_use_default
   end
 
   def setter?(method)

--- a/lib/hash.rb
+++ b/lib/hash.rb
@@ -20,15 +20,10 @@ class Hash
 
     if setter?(method)
       self[prop] = args.first
-    elsif key?(prop)
+    elsif key?(prop) || hash_dot_use_default
       self[prop]
     else
-      begin
-        super(method, args)
-      rescue NoMethodError
-        return self.default if hash_dot_use_default
-        raise
-      end
+      super(method, args)
     end
   end
 

--- a/lib/hash.rb
+++ b/lib/hash.rb
@@ -7,8 +7,8 @@ class Hash
   attr_accessor :use_dot_syntax
   attr_accessor :hash_dot_use_default
 
-  def to_dot(use_default=false)
-    dotify_hash(self, use_default)
+  def to_dot(use_default: false)
+    dotify_hash(self, use_default: use_default)
 
     self
   end
@@ -41,11 +41,11 @@ class Hash
   
   private
 
-  def dotify_hash(hash, use_default=false)
+  def dotify_hash(hash, use_default: false)
     hash.use_dot_syntax = true
     hash.hash_dot_use_default = use_default
 
-    hash.keys.each { |key| dotify_hash(hash[key], use_default) if hash[key].is_a?(Hash) }
+    hash.keys.each { |key| dotify_hash(hash[key], use_default: use_default) if hash[key].is_a?(Hash) }
   end
 
   def to_dot?

--- a/spec/hash_dot_spec.rb
+++ b/spec/hash_dot_spec.rb
@@ -41,9 +41,9 @@ describe "Hash dot syntax" do
 
     context "with a use_default set" do
       it "uses the hash default for unknown methods" do
-        one = { }.to_dot(true)
+        one = { }.to_dot(use_default: true)
         two = { }.to_dot
-        three = Hash.new('hi').to_dot(true)
+        three = Hash.new('hi').to_dot(use_default: true)
 
         expect( one.a ).to eq( nil )
         expect { two.a }.to raise_error( NoMethodError )

--- a/spec/hash_dot_spec.rb
+++ b/spec/hash_dot_spec.rb
@@ -38,5 +38,17 @@ describe "Hash dot syntax" do
     end
 
     it_behaves_like "an object", -> { { action: :to_dot } }
+
+    context "with a use_default set" do
+      it "uses the hash default for unknown methods" do
+        one = { }.to_dot(true)
+        two = { }.to_dot
+        three = Hash.new('hi').to_dot(true)
+
+        expect( one.a ).to eq( nil )
+        expect { two.a }.to raise_error( NoMethodError )
+        expect( three.a ).to be == 'hi'
+      end
+    end
   end
 end

--- a/spec/hash_dot_spec.rb
+++ b/spec/hash_dot_spec.rb
@@ -10,6 +10,13 @@ describe "Hash dot syntax" do
 
   context "given universal hash-dot syntax" do
     it_behaves_like "an object", -> { Hash.use_dot_syntax = true }
+
+    context "when respecting defaults" do
+      it_behaves_like "an object", -> {
+        Hash.use_dot_syntax = true
+        Hash.hash_dot_use_default = true
+      }
+    end
   end
 
   context "when using #to_dot" do
@@ -37,9 +44,26 @@ describe "Hash dot syntax" do
       expect( two.respond_to?(:a) ).to be_falsey
     end
 
+    it "raises an error if the property has been deleted" do
+      one = { a: 1 }.to_dot
+      expect( one.a ).to eq( 1 )
+      one.delete(:a)
+      expect{ one.a }.to raise_error( NoMethodError )
+    end
+
+    it "defaults to expected behavior when non existent methods are applied" do
+      one = { a: 1 }.to_dot
+      two = { a: 2 }
+
+      expect { one.non_existent_method }.to raise_error( NoMethodError )
+      expect { two.non_existent_method }.to raise_error( NoMethodError )
+    end
+
     it_behaves_like "an object", -> { { action: :to_dot } }
 
-    context "with a use_default set" do
+    context "when respecting defaults" do
+      it_behaves_like "an object", -> { { action: :to_dot, args: {use_default: true} } }
+
       it "uses the hash default for unknown methods" do
         one = { }.to_dot(use_default: true)
         two = { }.to_dot

--- a/spec/hash_dot_spec.rb
+++ b/spec/hash_dot_spec.rb
@@ -1,5 +1,7 @@
 require "spec_helper"
 require "shared_behavior/an_object_spec"
+require "shared_behavior/nomethoderror_spec"
+require "shared_behavior/use_default_spec"
 
 describe "Hash dot syntax" do
   context "given default universal hash-dot syntax" do
@@ -10,9 +12,14 @@ describe "Hash dot syntax" do
 
   context "given universal hash-dot syntax" do
     it_behaves_like "an object", -> { Hash.use_dot_syntax = true }
+    it_behaves_like "an object raising NoMethodError", -> { Hash.use_dot_syntax = true }
 
     context "when respecting defaults" do
       it_behaves_like "an object", -> {
+        Hash.use_dot_syntax = true
+        Hash.hash_dot_use_default = true
+      }
+      it_behaves_like "an object that respects Hash#default", -> {
         Hash.use_dot_syntax = true
         Hash.hash_dot_use_default = true
       }
@@ -44,25 +51,12 @@ describe "Hash dot syntax" do
       expect( two.respond_to?(:a) ).to be_falsey
     end
 
-    it "raises an error if the property has been deleted" do
-      one = { a: 1 }.to_dot
-      expect( one.a ).to eq( 1 )
-      one.delete(:a)
-      expect{ one.a }.to raise_error( NoMethodError )
-    end
-
-    it "defaults to expected behavior when non existent methods are applied" do
-      one = { a: 1 }.to_dot
-      two = { a: 2 }
-
-      expect { one.non_existent_method }.to raise_error( NoMethodError )
-      expect { two.non_existent_method }.to raise_error( NoMethodError )
-    end
-
     it_behaves_like "an object", -> { { action: :to_dot } }
+    it_behaves_like "an object raising NoMethodError", -> { { action: :to_dot } }
 
     context "when respecting defaults" do
       it_behaves_like "an object", -> { { action: :to_dot, args: {use_default: true} } }
+      it_behaves_like "an object that respects Hash#default", -> { { action: :to_dot, args: {use_default: true} } }
 
       it "uses the hash default for unknown methods" do
         one = { }.to_dot(use_default: true)

--- a/spec/shared_behavior/an_object_spec.rb
+++ b/spec/shared_behavior/an_object_spec.rb
@@ -25,12 +25,15 @@ shared_examples "an object" do |callback|
     result = callback.call
 
     if result.is_a?(Hash) && result[:action]
-      user.send(result[:action])
-      json_user.send(result[:action])
+      user.send(result[:action], result[:args] || {})
+      json_user.send(result[:action], result[:args] || {})
     end
   end
 
-  after(:each) { Hash.use_dot_syntax = false }
+  after(:each) {
+    Hash.use_dot_syntax = false
+    Hash.hash_dot_use_default = false
+  }
 
   it "allows hashes to access nested hashes" do
     expect( user.address.city ).to eq( user[:address][:city] )
@@ -51,12 +54,6 @@ shared_examples "an object" do |callback|
     expect( user.suffix ).to eq( "Esquire" )
   end
 
-  it "raises an error if the property has been deleted" do
-    user.delete(:email)
-
-    expect { user.email }.to raise_error( NoMethodError )
-  end
-
   it "handles JSON parsing of json strings" do
     expect( json_user.address.city ).to eq( user[:address][:city] )
 
@@ -65,11 +62,6 @@ shared_examples "an object" do |callback|
 
     expect( json_user.address.city ).to eq( "White Plains" )
     expect( json_user.name ).to eq( "New Name" )
-  end
-
-  it "defaults to expected behavior when non existent methods are applied" do
-    expect { json_user.non_existent_method }.to raise_error( NoMethodError )
-    expect { user.non_existent_method }.to raise_error( NoMethodError )
   end
 
   it "recognizes a key with a nil value" do

--- a/spec/shared_behavior/nomethoderror_spec.rb
+++ b/spec/shared_behavior/nomethoderror_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+shared_examples "an object raising NoMethodError" do |callback|
+  let(:user) {
+    {
+      name: "Example Name",
+      email: "example@gmail.com",
+      address: address,
+      phone: nil
+    }
+  }
+
+  let(:address) {
+    {
+      street: "1234 Sesame",
+      city: "New York",
+      state: "NY",
+      zip: "12345"
+    }
+  }
+
+  let(:json_user) { JSON.parse(user.to_json) }
+
+  before(:each) do
+    result = callback.call
+
+    if result.is_a?(Hash) && result[:action]
+      user.send(result[:action], result[:args] || {})
+      json_user.send(result[:action], result[:args] || {})
+    end
+  end
+
+  after(:each) {
+    Hash.use_dot_syntax = false
+    Hash.hash_dot_use_default = false
+  }
+
+  it "raises an error if the property has been deleted" do
+    user.delete(:email)
+    expect { user.email }.to raise_error(NoMethodError)
+  end
+
+  it "defaults to expected behavior when non existent methods are applied" do
+    expect { json_user.non_existent_method }.to raise_error( NoMethodError )
+    expect { user.non_existent_method }.to raise_error( NoMethodError )
+  end
+end

--- a/spec/shared_behavior/use_default_spec.rb
+++ b/spec/shared_behavior/use_default_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+shared_examples "an object that respects Hash#default" do |callback|
+  let(:user) {
+    {
+      name: "Example Name",
+      email: "example@gmail.com",
+      address: address,
+      phone: nil
+    }
+  }
+
+  let(:address) {
+    {
+      street: "1234 Sesame",
+      city: "New York",
+      state: "NY",
+      zip: "12345"
+    }
+  }
+
+  let(:json_user) { JSON.parse(user.to_json) }
+
+  before(:each) do
+    result = callback.call
+
+    if result.is_a?(Hash) && result[:action]
+      user.send(result[:action], result[:args] || {})
+      json_user.send(result[:action], result[:args] || {})
+    end
+    json_user.default = 'hello!'
+  end
+
+  after(:each) {
+    Hash.use_dot_syntax = false
+    Hash.hash_dot_use_default = false
+  }
+
+  it "uses the hash default for unknown methods" do
+    expect( user.a ).to eq( nil )
+    expect( json_user.a ).to eq( 'hello!' )
+  end
+end


### PR DESCRIPTION
The motivation here is that I am using `hash_dot` in erb templates and its typically much more convenient to return `nil` for not-found keys rather than raise an error.  This would also enable use of the `&.` operator in ruby 2.3+.

As an example, my current code looks like:

```
<% if foo.bar.baz rescue false -%>
...
<% end -%>
```

vs what I want it to look like:

```
<% if foo&.bar&.baz -%>
...
<% end -%>
```

I'd like to remove the `rescue false` since it tends to eat other errors.

PS - I considered migrating to OpenStruct, but some of my users are enjoying being able to do straight JSON dumps of the dotted hashes.