### PR TITLE
preserve use_default across array/obj boundaries

### DIFF
--- a/lib/hash.rb
+++ b/lib/hash.rb
@@ -44,7 +44,7 @@ class Hash
     case obj
     when Array
       obj.each do |el|
-        dotify_obj(el)
+        dotify_obj(el, use_default: use_default)
       end
     when Hash
       dotify_hash(obj, use_default: use_default)
@@ -57,7 +57,7 @@ class Hash
     hash.hash_dot_use_default = use_default
 
     hash.each_value do |val|
-      dotify_obj(val)
+      dotify_obj(val, use_default: use_default)
     end
   end
 

--- a/spec/shared_behavior/an_object_spec.rb
+++ b/spec/shared_behavior/an_object_spec.rb
@@ -5,6 +5,10 @@ shared_examples "an object" do |callback|
     {
       name: "Example Name",
       email: "example@gmail.com",
+      alt_emails: [
+        { type: "main", email: "foo@example.com" },
+        { type: "tech", email: "bar@example.com" }
+      ],
       address: address,
       phone: nil
     }
@@ -93,5 +97,9 @@ shared_examples "an object" do |callback|
     user.public_send("address.state=", "WA")
 
     expect(user.address.state).to eq( "WA" )
+  end
+
+  it "traverses nested arrays" do
+    expect(user.alt_emails.first.email).to eq("foo@example.com")
   end
 end

--- a/spec/shared_behavior/use_default_spec.rb
+++ b/spec/shared_behavior/use_default_spec.rb
@@ -6,6 +6,10 @@ shared_examples "an object that respects Hash#default" do |callback|
       name: "Example Name",
       email: "example@gmail.com",
       address: address,
+      alt_emails: [
+        { type: "main", email: "foo@example.com" },
+        { type: "tech", email: "bar@example.com" }
+      ],
       phone: nil
     }
   }
@@ -39,5 +43,9 @@ shared_examples "an object that respects Hash#default" do |callback|
   it "uses the hash default for unknown methods" do
     expect( user.a ).to eq( nil )
     expect( json_user.a ).to eq( 'hello!' )
+  end
+
+  it "uses the default across array boundaries" do
+    expect( user.alt_emails.first.foo ).to be_nil
   end
 end


### PR DESCRIPTION
This fixes a regression introduced in 2.3.0 when passing `use_default: true` to the `to_dot` call.  Some objects would use the hash's default, others would hit method_missing.