### PR TITLE
update travis dependency versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
-  - 2.3.6
-  - 2.4.2
-  - 2.5.0
-before_install: gem install bundler -v 1.10.3
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
+  - 2.6.2
+before_install: gem install bundler -v 1.17.3

--- a/hash_dot.gemspec
+++ b/hash_dot.gemspec
@@ -27,10 +27,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "json"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "rubocop", "~> 0.51"
+  spec.add_development_dependency "rubocop"
 end


### PR DESCRIPTION
Updates the tested versions of Ruby, and removes unnecessary development dependency restrictions.