### PR TITLE
avoid conflicts with other libraries

### DIFF
--- a/lib/hash_dot.rb
+++ b/lib/hash_dot.rb
@@ -1,6 +1,6 @@
-require "hash_dot/version"
-require "symbol"
-require "hash"
+require_relative "hash_dot/version"
+require_relative "symbol"
+require_relative "hash"
 
 module HashDot
 end


### PR DESCRIPTION
If another library also require top level libraries with the same name,
then require will not load it again, as it's supposed to be loaded
already. With hash.rb and symbol.rb at top level, being common names for
libraries doing monkey patching, it makes this library unsafe to use.